### PR TITLE
Prevent slider from expanding beyond the container

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -202,5 +202,6 @@ export default {
 
 .slider {
   margin-right: 20px;
+  max-width: 442px;
 }
 </style>


### PR DESCRIPTION
Fix for an issue picked up on Firefox 68 created at [Issue 7](https://github.com/pvanheus/1976_map_vue/issues/7)